### PR TITLE
ci: reinstall venv

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        if: steps.cache_venv.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
           source .venv/bin/activate


### PR DESCRIPTION
Fixes #35.

We still want to re-install the `src` package so that e.g. changes in the package are reflected in tests. Doing it like this means we'll get all the dependencies from the cache, but the core package is fresh.