### PR TITLE
ci: remove pip cache

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/mypy.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/mypy.yml
@@ -34,8 +34,6 @@ jobs:
         if: steps.cache_venv.outputs.cache-hit != 'true'
         with:
           python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Install dependencies
         shell: bash

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -39,8 +39,6 @@ jobs:
         if: steps.cache_venv.outputs.cache-hit != 'true'
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
Pip cache is frequently the slowest, probably due to conflicts, e.g. see here: https://github.com/Aarhus-Psychiatry-Research/psycop-model-training/actions/runs/4468668047/jobs/7849712046?pr=431

Moreover, github actions runners have access to a local cache, which is already super fast. I recommend we disable this for now.