### PR TITLE
ci: add test comment annotations

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   pytest:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
     strategy:
       matrix:
         os: [ubuntu-latest] #, macos-latest]
@@ -54,20 +59,21 @@ jobs:
           source .venv/bin/activate
           pytest --durations=0 -n 2 -x --junitxml=pytest.xml --cov-report=term-missing --cov=src/ tests/
 
-      # if it is run on ubuntu-latest, python 3.9, then create the badge
+      - name: Test report on failures
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        id: test_report_with_annotations
+        if: ${{ github.actor != 'dependabot[bot]' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
+        with:
+          comment_mode: "failures"
+          files: |
+            pytest.xml
+
       - name: Pytest coverage comment
         id: coverage-comment
         uses: MishaKav/pytest-coverage-comment@main
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && (success() || failure()) }}
         with:
           create-new-comment: false
           report-only-changed-files: true
           pytest-coverage-path: pytest-coverage.txt
           junitxml-path: ./pytest.xml
-
-      - name: Check the output coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
-        shell: bash
-        run: |
-          echo "Coverage Report - ${{ steps.coverage-comment.outputs.coverage }}"
-          echo "Coverage Color - ${{ steps.coverage-comment.outputs.color }}"

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test report on failures
         uses: EnricoMi/publish-unit-test-result-action@v2
         id: test_report_with_annotations
-        if: ${{ github.actor != 'dependabot[bot]' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
         with:
           comment_mode: "failures"
           files: |
@@ -71,7 +71,7 @@ jobs:
       - name: Pytest coverage comment
         id: coverage-comment
         uses: MishaKav/pytest-coverage-comment@main
-        if: ${{ github.actor != 'dependabot[bot]' && (success() || failure()) }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }}
         with:
           create-new-comment: false
           report-only-changed-files: true


### PR DESCRIPTION
Would like an extra set of eyes on the config - feel free to merge if you think it looks good :-)

Has been tested here: https://github.com/Aarhus-Psychiatry-Research/psycop-model-training/pull/448