### PR TITLE
ci: exempt bot PRs from stalebot

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/cruft.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/cruft.yml
@@ -63,3 +63,4 @@ jobs:
           body: "🌲 Cruft updates"
           token: ${{ secrets.PAT }}
           commit-message: "ci: update cruft"
+          labels: "dependencies" # This makes the PR exempt from the stale bot

--- a/{{cookiecutter.project_name}}/.github/workflows/stalebot.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/stalebot.yml
@@ -19,4 +19,5 @@ jobs:
           days-before-pr-close: 7
           close-pr-message: "This PR was closed automatically. Feel free to re-open it if you still want to work on it."
           close-pr-label: "closed-by-stalebot"
-          operations-per-run: 1000
+          operations-per-run: 20
+          exempt-pr-labels: "dependencies,bot"


### PR DESCRIPTION
As the title says. Avoids getting stalebot notifications for dependencies that couldn't merge because of some unrelated error.

I typically just fix the error, dependabot rebases the PRs, and then they merge by themselves. Don't need to be alerted to them :-)