### PR TITLE
ci: updated ci to work with windows

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -49,14 +49,23 @@ jobs:
         shell: bash
         run: |
           python -m venv .venv
-          source .venv/bin/activate
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            source ${{ env.venv_path }}/Scripts/activate
+          else
+            source ${{ env.venv_path }}/bin/activate
+          fi
           python -m pip install --upgrade pip
           pip install -e .[tests]
 
       - name: Run and write pytest
         shell: bash
         run: |
-          source .venv/bin/activate
+          # activate venv dependent on the os
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            source ${{ env.venv_path }}/Scripts/activate
+          else
+            source ${{ env.venv_path }}/bin/activate
+          fi
           pytest --durations=0 -n 2 -x --junitxml=pytest.xml --cov-report=term-missing --cov=src/ tests/
 
       - name: Test report on failures

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           python -m venv .venv
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            source ${{ env.venv_path }}/Scripts/activate
+            source .venv/Scripts/activate
           else
-            source ${{ env.venv_path }}/bin/activate
+            source .venv/bin/activate
           fi
           python -m pip install --upgrade pip
           pip install -e .[tests]
@@ -62,9 +62,9 @@ jobs:
         run: |
           # activate venv dependent on the os
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            source ${{ env.venv_path }}/Scripts/activate
+            source .venv/Scripts/activate
           else
-            source ${{ env.venv_path }}/bin/activate
+            source .venv/bin/activate
           fi
           pytest --durations=0 -n 2 -x --junitxml=pytest.xml --cov-report=term-missing --cov=src/ tests/
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        os: [ubuntu-latest] #, macos-latest]
-        python-version: ["3.9"] # , "3.8"]
+        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        python-version: ["3.9"] # , "3.10"]
 
     # This allows a subsequently queued workflow run to interrupt previous runs
     concurrency:
@@ -62,7 +62,7 @@ jobs:
       - name: Test report on failures
         uses: EnricoMi/publish-unit-test-result-action@v2
         id: test_report_with_annotations
-        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' &&  github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
         with:
           comment_mode: "failures"
           files: |
@@ -71,7 +71,7 @@ jobs:
       - name: Pytest coverage comment
         id: coverage-comment
         uses: MishaKav/pytest-coverage-comment@main
-        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' &&  github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }}
         with:
           create-new-comment: false
           report-only-changed-files: true


### PR DESCRIPTION
Fixed error which assumed it was run on only one instance of ubuntu.

Martin it seems like quite a lot of complexity to introduce for the cache vs something like:

```
steps:
- uses: actions/checkout@v3
- uses: actions/setup-python@v4
  with:
    python-version: ${{ matrix.python-version }}
    cache: 'pip'
    cache-dependency-path: |
      **/pyproject.toml
```

If you still think it is worth it we can simply keep it like this.