### PR TITLE
build: make pyright output less verbose

### DIFF
--- a/{{cookiecutter.project_name}}/.github/recommended_repo_setup.md
+++ b/{{cookiecutter.project_name}}/.github/recommended_repo_setup.md
@@ -30,7 +30,7 @@
      * Require status checks to pass before merging
        * Require branches to be up to date before merging
        * Status checks that are required:
-         * mypy (type hinting)
+         * static_type_checks (type hinting)
          * pre-commit (formatting)
          * pytest (tests)
          * check_for_rej (check for residual cruft updates)

--- a/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
@@ -91,4 +91,5 @@ jobs:
         id: fail_run
         if: ${{steps.pyright.outputs.pyright_failed == 1}}
         run: |
+          source .venv/bin/activate
           pyright . # Rerunning pyright isn't optimal computationally, but typically takes no more than a couple of seconds, and this ensures that the errors are in the failing step

--- a/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
@@ -1,7 +1,7 @@
-# We do not include mypy as a pre-commit hook because pre-commit hooks
-# are installed in their own virtual environment, so mypy cannot
+# We do not include static_type_checks as a pre-commit hook because pre-commit hooks
+# are installed in their own virtual environment, so static_type_checks cannot
 # use stubs from imports
-name: mypy
+name: static_type_checks
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
     branches: [main]
 
 jobs:
-  mypy:
+  static_type_checks:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
@@ -72,13 +72,18 @@ jobs:
         id: add_comment
         with:
           message: |
-            ✨ Looks like pyright failed ✨
-
-            If you want to fix this, we recommend doing it locally by either:
-              a) Enabling pyright in VSCode and going through the errors in the problems tab (VSCode settings > Python > Analysis: Type checking mode > "basic")
-              b) Debugging via the command line
-                1. Installing pyright, which is included in the dev dependencies: `pip install -e ".[dev]"`
-                2. Diagnosing the errors by running `pyright .`
+          ✨ Looks like pyright failed ✨
+          
+          If you want to fix this, we recommend doing it locally by either:
+          
+            a) Enabling pyright in VSCode and going through the errors in the problems tab 
+          
+          `VSCode settings > Python > Analysis: Type checking mode > "basic"`
+          
+            b) Debugging via the command line
+          
+              1. Installing pyright, which is included in the dev dependencies: `pip install -e ".[dev]"`
+              2. Diagnosing the errors by running `pyright .`
 
       - uses: mshick/add-pr-comment@v2
         if: ${{ steps.pyright.outputs.pyright_failed == 0 && steps.find_comment.outputs.comment-id != '' && github.event_name == 'pull_request'}}

--- a/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
@@ -72,18 +72,18 @@ jobs:
         id: add_comment
         with:
           message: |
-          ✨ Looks like pyright failed ✨
+            ✨ Looks like pyright failed ✨
           
-          If you want to fix this, we recommend doing it locally by either:
-          
-            a) Enabling pyright in VSCode and going through the errors in the problems tab 
-          
-          `VSCode settings > Python > Analysis: Type checking mode > "basic"`
-          
-            b) Debugging via the command line
-          
-              1. Installing pyright, which is included in the dev dependencies: `pip install -e ".[dev]"`
-              2. Diagnosing the errors by running `pyright .`
+            If you want to fix this, we recommend doing it locally by either:
+            
+              a) Enabling pyright in VSCode and going through the errors in the problems tab 
+            
+            `VSCode settings > Python > Analysis: Type checking mode > "basic"`
+            
+              b) Debugging via the command line
+            
+                1. Installing pyright, which is included in the dev dependencies: `pip install -e ".[dev]"`
+                2. Diagnosing the errors by running `pyright .`
 
       - uses: mshick/add-pr-comment@v2
         if: ${{ steps.pyright.outputs.pyright_failed == 0 && steps.find_comment.outputs.comment-id != '' && github.event_name == 'pull_request'}}

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -1,5 +1,4 @@
 # Python
-.mypy_cache/
 /.python-version
 /.pytype/
 /dist/

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -67,6 +67,7 @@ documentation = "https://{{cookiecutter.github_user}}.github.io/{{cookiecutter.p
 
 [tool.pyright]
 exclude = [".*venv*"]
+pythonPlatform = "Darwin"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -117,7 +117,6 @@ exclude = [
   ".eggs",
   ".git",
   ".hg",
-  ".mypy_cache",
   ".nox",
   ".pants.d",
   ".pytype",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -31,7 +31,8 @@ name = "{{cookiecutter.license}}"
 [project.optional-dependencies]
 dev = [
   "cruft",
-  "pyright",  
+  "pyright",
+  "pyright-polite",
   "pre-commit==2.20.0,<2.21.0",
   "ruff==0.0.254", # important that these match the pre-commit hooks
   "black[jupyter]==22.8.0", # important that these match the pre-commit hooks

--- a/{{cookiecutter.project_name}}/tasks.py
+++ b/{{cookiecutter.project_name}}/tasks.py
@@ -281,7 +281,7 @@ def test_for_rej():
 
 @task
 def lint(c: Context, auto_fix: bool = False):
-    """Lint the project using the pre-commit hooks and mypy."""
+    """Lint the project."""
     test_for_rej()
     pre_commit(c=c, auto_fix=auto_fix)
     static_type_checks(c)

--- a/{{cookiecutter.project_name}}/tasks.py
+++ b/{{cookiecutter.project_name}}/tasks.py
@@ -207,7 +207,7 @@ def pre_commit(c: Context, auto_fix: bool):
 
 def static_type_checks(c: Context):
     echo_header(f"{Emo.CLEAN} Running static type checks")
-    c.run("pyright .", pty=True)
+    c.run("pyright-polite .", pty=True)
 
 
 @task


### PR DESCRIPTION

* Added pyright-polite https://github.com/jamielinux/pyright-polite

* Also renamed the mypy step to "static_type_checks". In general, I think we should keep things as general as possible to avoid breaking downstream repos branch protection rules :-)

* Set pyright's pythonPlatform to `Darwin`. Only relevant for a `float`/float64` discrepancy in numpy which doesn't matter at runtime. Ensures alignment between running locally and on github actions, and decreases false positives.

![image](https://user-images.githubusercontent.com/8526086/232992980-efbcedc1-cca9-41a4-a6b2-cceb27a4bbc1.png)

