### PR TITLE
Only set lower bounds for versions

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -29,32 +29,33 @@ name = "{{cookiecutter.license}}"
 {%- endif %}
 [project.optional-dependencies]
 dev = [
-  "cruft",
-  "pyright",
-  "pyright-polite",
-  "pre-commit==2.20.0,<2.21.0",
-  "ruff==0.0.254", # important that these match the pre-commit hooks
-  "black[jupyter]==22.8.0", # important that these match the pre-commit hooks
-  "pandas-stubs", # type stubs for pandas
-  "invoke",
+  "cruft>=2.0.0",
+  "pyright>=1.1.165",
+  "pyright-polite>=0.0.1",
+  "pre-commit>=2.20.0",
+  "ruff>=0.0.254",
+  "black[jupyter]>=22.8.0",
+  "pandas-stubs>=0.0.0", # type stubs for pandas
+  "invoke>=2.0.0",
 ]
 tests = [
-  "pytest>=7.1.3,<7.3.0",
-  "pytest-cov>=3.0.0,<3.1.0",
-  "pytest-xdist>=3.0.0,<3.2.0",
-  "pytest-sugar>=0.9.4,<0.10.0",
-  "tox",
+  "pytest>=7.1.3",
+  "pytest-cov>=3.0.0",
+  "pytest-xdist>=3.0.0",
+  "pytest-sugar>=0.9.4",
+  "tox>=4.5.0",
 ]
 docs = [
-  "sphinx>=5.3.0,<5.4.0",
-  "furo>=2022.12.7,<2022.12.8",  # theme
-  "sphinx-copybutton>=0.5.1,<0.5.2",
-  "sphinxext-opengraph>=0.7.3,<0.7.4",
-  "sphinx_design>=0.3.0,<0.3.1",
-  "sphinx_togglebutton>=0.2.3,<0.4.0",
-  "myst-nb>=0.6.0,<1.17.0",  # for rendering notebooks
-  "jupyter>=1.0.0,<1.1.0",  # for tutorials
+  "sphinx>=5.3.0",
+  "furo>=2022.12.7",  # theme
+  "sphinx-copybutton>=0.5.1",
+  "sphinxext-opengraph>=0.7.3",
+  "sphinx_design>=0.3.0",
+  "sphinx_togglebutton>=0.2.3",
+  "myst-nb>=0.6.0",  # for rendering notebooks
+  "jupyter>=1.0.0",  # for tutorials
 ]
+
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
Benefits:

- No pr. when you create the repo from dependabot
- potentially better behaviour
- re. ruff and black not being the same as pre-commit hook. I like the idea that it is unbounded. Generally most style changes are backward compatible but not forward compatible.