### PR TITLE
add pypright to ci

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/static_type_checks.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          pip install invoke tox
+          pip install invoke tox pyright
 
       - name: Run static type checker
         id: pyright


### PR DESCRIPTION
@MartinBernstorff I don't feel like this should be needed, but the ci fails without it. 

To ensure the same pyright version, we could install the project, but then why use tox?